### PR TITLE
feat: Support configuring a domain name as nameserver

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[*.{yml,sls}]
+[*.{yml,sls,md}]
 indent_size = 2
 
 [acme/init.sls]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,22 @@
+# markdownlint config
+
+# The CHANGELOG contains duplicated headers by design
+MD024: false
+
+# MD013/line-length: disable line length for all. We prefer lines as
+# long as paragraph with in-editor line breaks.
+MD013: false
+
+# MD033/no-inline-html: allow often need tags
+MD033:
+  allowed_elements:
+    - figure
+    - figcaption
+
+# MD046/code-block-style: code block style conflicting with
+# admonitions...
+MD046: false
+
+# MD048/code-fence-style: code fence style
+MD048:
+  style: backtick

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-    "python.pythonPath": "/usr/bin/python3",
-    "python.formatting.provider": "black",
     "files.exclude": {
         "**/__pycache__": true,
         "**/.tox": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,29 +1,41 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 ### Added
-- Allow to disable directory creation
+
+- Allow disabling directory creation
+- Support configuring a domain name as the nameserver address
 
 ## [1.2.0] - 2021-02-15
+
 ### Added
-- Support for dnspython 2.0, Salt 3002, Python 3.9
-- Allow to customize file path for private key and certificate files
+
+- Support for `dnspython` 2.0, Salt 3002, Python 3.9
+- Allow customizing file path for private key and certificate files
 
 ## [1.1.0] - 2020-08-04
+
 ### Added
+
 - Check DNS propagation to nameservers
 - Option to configure account directory
 
 ## [1.0.1] - 2020-07-16
+
 ### Fixed
-- Catch missing dnspython in acme_dns
+
+- Catch missing `dnspython` in `acme_dns`
 
 ## 1.0.0 - 2020-07-13
+
 ### Added
+
 - First release with basic feature set
 
 [Unreleased]: https://github.com/jgraichen/salt-acme/compare/v1.2.0...HEAD

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ gitfs_remotes:
 
 The execution modules usually are used on the master too. Please synchronize the modules and runners on the master with `salt-run`:
 
-```
+```console
 $ salt-run saltutil.sync_all
 modules:
     - modules.acme
@@ -98,7 +98,7 @@ peer_run:
     - acme.sign
 ```
 
-The runner can validation signing requests using an authorization file. This file defines which minion is allowed to requests a domain:
+The runner can validation signing requests using an authorization file. This file defines which minion is allowed to request a domain:
 
 ```yaml
 # /etc/salt/master
@@ -123,7 +123,7 @@ Minion IDs and domain names are matched with a glob-style pattern using [`fnmatc
 
 The `acme.sign` execution modules uses other modules to install and remove challenges. These resolver modules must implement a common interface:
 
-An `install` and `remove` function, both accepting a `name`, a list of `tokens` and additional arguments, passed from the resolver configuration. The `tokens` arguments is a list of `{"name": "example.org", "token": "abc....def"}` dicts.
+An `install` and `remove` function, both accepting a `name`, a list of `tokens` and additional arguments, passed from the resolver configuration. The `tokens` arguments is a list of `{"name": "example.org", "token": "abc....def"}` dictionaries.
 
 The following resolvers are included in this repository.
 
@@ -140,13 +140,13 @@ acme:
       module: acme_dns
 
       # Which name server to use
-      nameserver: 127.0.0.153  # required
+      nameserver: 127.0.0.153  # required; can be domain name
       port: 53
 
       # Zone
       #
-      # Zone to update. If not given, the resolver name (above)
-      # is used as zone name.
+      # Zone to update. If not given, the resolver name
+      # (here: example.org) will be used as the zone name.
       zone: example.org
 
       # Alias mode
@@ -168,7 +168,7 @@ acme:
 
       # Verify DNS record propagation
       #
-      # This will check all nameserver listed in the zone to
+      # This will check all nameservers listed in the zone to
       # have at least the serial from the update in their SOA
       # records.
       verify: True

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - 127.0.0.1:15000:15000  # HTTPS Management API
       - 127.0.0.153:53:53/tcp  # DNS
       - 127.0.0.153:53:53/udp  # DNS
+      - 127.0.0.1:5300:53/tcp  # DNS
+      - 127.0.0.1:5300:53/udp  # DNS
   knot:
     image: cznic/knot:3.4
     command: knotd

--- a/test/modules/test_acme_dns.py
+++ b/test/modules/test_acme_dns.py
@@ -2,11 +2,11 @@
 # pylint: disable=missing-docstring
 # pylint: disable=redefined-outer-name
 
-import dns
+
 import pytest
 from conftest import knotc
 from dns.rdatatype import TXT
-from dns.resolver import Resolver
+from dns.resolver import NXDOMAIN, Resolver
 
 
 @pytest.fixture()
@@ -24,7 +24,19 @@ def test_install(minion, resolver: Resolver):
     )
 
     answer = resolver.resolve("_acme-challenge.example.com.", TXT)[0]
-    assert list(answer.strings) == [b"secret"]
+    assert list(answer.strings) == [b"secret"]  # type: ignore
+
+
+def test_install_name_and_port(minion, resolver: Resolver):
+    minion.mods["acme_dns.install"](
+        "example.com",
+        [{"name": "example.com", "token": "secret"}],
+        nameserver="localhost",
+        port=5300,
+    )
+
+    answer = resolver.resolve("_acme-challenge.example.com.", TXT)[0]
+    assert list(answer.strings) == [b"secret"]  # type: ignore
 
 
 def test_install_zone(minion, resolver: Resolver):
@@ -36,7 +48,7 @@ def test_install_zone(minion, resolver: Resolver):
     )
 
     answer = resolver.resolve("_acme-challenge.example.com.", TXT)[0]
-    assert list(answer.strings) == [b"secret"]
+    assert list(answer.strings) == [b"secret"]  # type: ignore
 
 
 def test_install_alias(minion, resolver: Resolver):
@@ -48,7 +60,7 @@ def test_install_alias(minion, resolver: Resolver):
     )
 
     answer = resolver.resolve("acme.example.com.", TXT)[0]
-    assert list(answer.strings) == [b"secret"]
+    assert list(answer.strings) == [b"secret"]  # type: ignore
 
 
 def test_install_tsig(minion, resolver: Resolver):
@@ -60,7 +72,7 @@ def test_install_tsig(minion, resolver: Resolver):
     )
 
     answer = resolver.resolve("_acme-challenge.example.org.", TXT)[0]
-    assert list(answer.strings) == [b"secret"]
+    assert list(answer.strings) == [b"secret"]  # type: ignore
 
 
 def test_remove(minion, resolver: Resolver):
@@ -79,7 +91,7 @@ def test_remove(minion, resolver: Resolver):
     )
 
     answer = resolver.resolve("_acme-challenge.example.com.", TXT)[0]
-    assert list(answer.strings) == [b"value-1"]
+    assert list(answer.strings) == [b"value-1"]  # type: ignore
 
 
 def test_remove_zone(minion, resolver: Resolver):
@@ -94,7 +106,7 @@ def test_remove_zone(minion, resolver: Resolver):
         zone="example.com",
     )
 
-    with pytest.raises(dns.resolver.NXDOMAIN):
+    with pytest.raises(NXDOMAIN):
         resolver.resolve("_acme-challenge.example.org.", TXT)
 
 
@@ -110,7 +122,7 @@ def test_remove_tsig(minion, resolver: Resolver):
         tsig="hmac-sha256:acme:opCLn9NMrbY0xKB8lWs2KM2lgQsEW5LdvsVtxnoRJIo=",
     )
 
-    with pytest.raises(dns.resolver.NXDOMAIN):
+    with pytest.raises(NXDOMAIN):
         resolver.resolve("_acme-challenge.example.org.", TXT)
 
 
@@ -126,5 +138,5 @@ def test_remove_alias(minion, resolver: Resolver):
         alias="acme.example.com",
     )
 
-    with pytest.raises(dns.resolver.NXDOMAIN):
+    with pytest.raises(NXDOMAIN):
         resolver.resolve("acme.example.org.", TXT)


### PR DESCRIPTION
The configured name server had to be an IP address, since `dnspython` does not accept names. This CL extends the `acme_dns` module to handle a domain name by looking it up and trying all addresses. The first address that accept a DNS request will be used.